### PR TITLE
v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,3 +108,39 @@ continue the request for the `HandleFunc`
 ## 0.13.0
 
 * Fixing go mod
+
+## 0.14.0
+
+* IResponse implemented on the HandleFunc. It was only possible to reply JSend messages, now on, it is possible to
+return anything that implements `IResponse` interface, which means anything besides JSend.
+* `EnableCORS()` now on is a method on the `IServer`. To enable CORS it is only needed to call the method.
+* Helpers for responses. **Status**: 
+    * ProxyAuthRequired
+    * RequestTimeout
+    * Conflict
+    * Gone
+    * LengthRequired
+    * PreconditionFailed
+    * RequestEntityTooLarge
+    * RequestURITooLong
+    * UnsupportedMediaType
+    * RequestedRangeNotSatisfiable
+    * ExpectationFailed
+    * Teapot
+    * MisdirectedRequest
+    * UnprocessableEntity
+    * Locked
+    * FailedDependency
+    * TooEarly
+    * UpgradeRequired
+    * PreconditionRequired
+    * TooManyRequests
+    * RequestHeaderFieldsTooLarge
+    * UnavailableForLegalReasons
+    * NonAuthoritativeInfo
+    * ResetContent
+    * PartialContent
+    * MultiStatus
+    * AlreadyReported
+    * IMUsed
+* Go doc support

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # Httping go
 
-A helper to create APIs on golang with [JSend responses](https://github.com/omniti-labs/jsend)
+[![Release](https://img.shields.io/badge/release-0.14.2-blue)](https://github.com/ntopus/httping-go/releases)
+![Coverage](https://img.shields.io/badge/coverage-98%25-success)
+[![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-9cf)](https://godoc.org/github.com/ntopus/httping-go)
+
+A library for creating API's on golang that comes with a [JSend responses](https://github.com/omniti-labs/jsend) helper
 
 * **[CHANGELOG](CHANGELOG.md)**
+
+Checkout some [example](examples).
 
 ## Getting started
 
@@ -26,6 +33,12 @@ It is possible to set a server with CORS configuration. Just need to set true on
 ```go
 server := httping.NewHttpServer("", 3000, true)
 ```  
+
+The server has support to CORS. To enable it, you just need to do
+
+```go
+server.EnableCORS()
+```
 
 ### Creating a route
 
@@ -52,7 +65,7 @@ So now there are two new **routes**: `http://localhost:3000/example/create` and 
 ### Adding a method on the route
 
 ```go
-routeExample.AddMethod("POST", func(request HttpRequest) (int, *ResponseMessage) {
+routeExample.AddMethod("POST", func(request httping.HttpRequest) httping.IResponse {
     if len(request.body) == 0 {
         return httping.NewResponse(404)
     }
@@ -67,7 +80,7 @@ _p.s.: only http methods and http codes are allowed_
 And it is possible to add different **methods** on the same **route**. 
 
 ```go
-routeExample.AddMethod("GET", func(request HttpRequest) (int, *ResponseMessage) {
+routeExample.AddMethod("GET", func(request httping.HttpRequest) httping.IResponse {
     if len(request.body) == 0 {
         return httping.NewResponse(404)
     }
@@ -80,7 +93,7 @@ Now the route `http://localhost:3000/example` has the **methods** `GET` and `POS
 If you will not use the route two or more times you can directly create a route and add a method 
 
 ```go
-server.NewRoute(nil, "/create").AddMethod("POST", func(request httping.HttpRequest) (int, *httping.ResponseMessage) {
+server.NewRoute(nil, "/create").AddMethod("POST", func(request httping.HttpRequest) httping.IResponse {
 		return httping.NewResponse(200)
 	})
 ```
@@ -100,7 +113,7 @@ This will build a Response message with the status correct according with the ht
 **Example**
 
 ```go
-server.NewRoute(nil, "/create").POST(func(request httping.HttpRequest) (int, *httping.ResponseMessage) {
+server.NewRoute(nil, "/create").POST(func(request httping.HttpRequest) httping.IResponse {
 		return httping.NewResponse(200).AddData("success")
 	})
 ```
@@ -114,7 +127,7 @@ There are a few helpers for the most commons http status codes.
 **Example**
 
 ```go
-server.NewRoute(nil, "/create").POST(func(request httping.HttpRequest) (int, *httping.ResponseMessage) {
+server.NewRoute(nil, "/create").POST(func(request httping.HttpRequest) httping.IResponse {
 		return httping.OK("data example")
 	})
 ```
@@ -128,7 +141,7 @@ It is possible to add a middleware handler function to the server or a route
 
 ```go
 server := httping.NewHttpServer(3000).AddMiddleware(
-    func(request HttpRequest) (*ResponseMessage) {
+    func(request httping.HttpRequest) httping.IResponse {
         if request.Headers["Authorization"][0] != "token"{
             return httping.Unauthorized("not authorized")
         }
@@ -137,7 +150,7 @@ server := httping.NewHttpServer(3000).AddMiddleware(
 )
 ```
 
-If you return `ResponseMessage`: The server will **not** let the request proceed and it will return the response returned.
+If you return `IResponse`: The server will **not** let the request proceed and it will return the response returned.
 
 If you return `nil`, the server will let the request proceed to the route's `handleFunc`
 

--- a/examples/custom_responses/main.go
+++ b/examples/custom_responses/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"github.com/ntopus/httping-go"
+	"net/http"
+)
+
+//The httping package has a helper for responses. But you can build your own response builder
+
+func main() {
+
+	//Creating a server localhost port 8080
+	server := httping.NewHttpServer("", 8080)
+
+	//Setting up a route with a custom response
+	server.NewRoute(nil, "/example").POST(func(request httping.HttpRequest) httping.IResponse {
+		return &response{
+			data:       "OK!",
+			statusCode: http.StatusOK,
+		}
+	})
+
+	//Running the server
+	//If you close the server, you just need to call the closeServerFunc()
+	//chErr will receive any error that happened on the server
+	//We will have 1 routes on this server:
+	//POST /example
+	closeServeFunc, chErr := server.RunServer()
+
+	<-chErr
+	err := closeServeFunc()
+	if err != nil {
+		fmt.Sprintln(err.Error())
+	}
+}
+
+//To create a custom response it is only needed to implement the interface IResponse
+type response struct {
+	data       string
+	statusCode int
+}
+
+func (r *response) Headers() map[string][]string {
+	return nil
+}
+
+func (r *response) Cookies() []*http.Cookie {
+	return nil
+}
+
+func (r *response) Response() interface{} {
+	return r.data
+}
+
+func (r *response) StatusCode() int {
+	return r.statusCode
+}

--- a/examples/routes_and_middleware/main.go
+++ b/examples/routes_and_middleware/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"github.com/ntopus/httping-go"
+)
+
+func main() {
+
+	//Creating a server localhost port 8080
+	server := httping.NewHttpServer("", 8080)
+
+	//If your server will be accessed by browsers we recommend you to enable cors
+	server.EnableCORS()
+
+	//Adding a middleware func to the server. It means the every request to the server will pass by the middleware
+	//It is possible to remove the middleware to a specific route. The example is down below.
+	server.AddMiddleware(func(request httping.HttpRequest) httping.IResponse {
+		if request.Body == nil {
+
+			//This lib has some helpers to create response with JSend pattern.
+			//Here we are returning a BadRequest with a json data.
+			return httping.BadRequest(`{"body": "body is required"}`)
+		}
+
+		//If the middleware handle function return nil
+		//It means the the request will continue to the next handle functions
+		return nil
+	})
+
+	//Setting up a route
+	v1Route := server.NewRoute(nil, "/v1")
+
+	//Setting up a new route with a route base
+	//The route will be localhost:8080/v1/example
+	exampleRoute := server.NewRoute(v1Route, "/example")
+
+	//Adding a method POST to the exampleRoute with the handleFunc()
+	exampleRoute.POST(handleFunc())
+
+	//Adding a method GET to the same exampleRoute with the handleFunc2()
+	exampleRoute.GET(handleFunc2())
+
+	//Creating a new route with a route base without the server middleware handle function
+	//Adding already a POST method to the route with the handleFunc2()
+	server.NewRoute(v1Route, "/noMiddleware").SetMiddleware(nil).POST(handleFunc2())
+
+	//Running the server
+	//If you close the server, you just need to call the closeServerFunc()
+	//chErr will receive any error that happened on the server
+	//We will have 3 routes on this server:
+	//POST /v1/example
+	//GET /v1/example
+	//POST /v1/noMiddleware
+	closeServeFunc, chErr := server.RunServer()
+
+	<-chErr
+	err := closeServeFunc()
+	if err != nil {
+		fmt.Sprintln(err.Error())
+	}
+}
+
+func handleFunc() httping.HandlerFunc {
+	return func(request httping.HttpRequest) httping.IResponse {
+		if request.Params["authorization"] == "" {
+			return httping.Unauthorized(map[string]string{
+				"authorization": "unauthorized",
+			})
+		}
+
+		//Anything with the request can be made
+
+		return httping.NoContent()
+	}
+}
+
+func handleFunc2() httping.HandlerFunc {
+	return func(request httping.HttpRequest) httping.IResponse {
+
+		//Anything with the request can be made
+
+		return httping.OK("OK!")
+	}
+}

--- a/http_server.go
+++ b/http_server.go
@@ -6,12 +6,10 @@ import (
 	"strconv"
 )
 
-func NewHttpServer(host string, port int, cors ...bool) IServer {
+// Creates a HTTP Server
+func NewHttpServer(host string, port int) IServer {
 	engine := gin.Default()
 	engine.HandleMethodNotAllowed = true
-	if len(cors) > 0 && cors[0] == true {
-		engine.Use(corsMiddleware())
-	}
 	server := &http.Server{
 		Addr:    host + ":" + strconv.Itoa(port),
 		Handler: engine,
@@ -25,6 +23,7 @@ type httpServer struct {
 	middleware []HandlerFunc
 }
 
+// It adds a new route to your server. You can add or create as many as you need.
 func (server *httpServer) NewRoute(baseRoute IRoute, path string) IRoute {
 	if baseRoute != nil {
 		g := baseRoute.getRoute().route.Group(path)
@@ -34,6 +33,8 @@ func (server *httpServer) NewRoute(baseRoute IRoute, path string) IRoute {
 	return &route{route: g, middleware: server.middleware}
 }
 
+// It runs your server.
+// Your server cannot receive any other configuration while it is rolling.
 func (server *httpServer) RunServer() (ServerCloseFunc, chan error) {
 	chErr := make(chan error)
 	go func(server *http.Server) {
@@ -46,13 +47,22 @@ func (server *httpServer) RunServer() (ServerCloseFunc, chan error) {
 	}, chErr
 }
 
+// It sets the middleware of your server.
 func (server *httpServer) SetMiddleware(middleware []HandlerFunc) IServer {
 	server.middleware = middleware
 	return server
 }
 
+// If adds a middleware to your server. It means that all your routes will pass by this middleware.
+// If you need to add a middleware only in a route you can do it on the AddMiddleware func of IRoute
 func (server *httpServer) AddMiddleware(middleware HandlerFunc) IServer {
 	server.middleware = append(server.middleware, middleware)
+	return server
+}
+
+// If you server needs CORS specification you can enable it on your server just calling this function
+func (server *httpServer) EnableCORS() IServer {
+	server.engine.Use(corsMiddleware())
 	return server
 }
 

--- a/response_helpers.go
+++ b/response_helpers.go
@@ -18,6 +18,25 @@ func NoContent() *ResponseMessage {
 	return NewResponse(http.StatusNoContent)
 }
 
+func NonAuthoritativeInfo(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusNonAuthoritativeInfo).AddData(data)
+}
+func ResetContent(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusResetContent).AddData(data)
+}
+func PartialContent(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusPartialContent).AddData(data)
+}
+func MultiStatus(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusMultiStatus).AddData(data)
+}
+func AlreadyReported(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusAlreadyReported).AddData(data)
+}
+func IMUsed(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusIMUsed).AddData(data)
+}
+
 func BadRequest(data interface{}) *ResponseMessage {
 	return NewResponse(http.StatusBadRequest).AddData(data)
 }
@@ -40,6 +59,73 @@ func MethodNotAllowed(data interface{}) *ResponseMessage {
 
 func NotAcceptable(data interface{}) *ResponseMessage {
 	return NewResponse(http.StatusNotAcceptable).AddData(data)
+}
+
+func ProxyAuthRequired(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusProxyAuthRequired).AddData(data)
+}
+func RequestTimeout(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusRequestTimeout).AddData(data)
+}
+func Conflict(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusConflict).AddData(data)
+}
+func Gone(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusGone).AddData(data)
+}
+func LengthRequired(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusLengthRequired).AddData(data)
+}
+func PreconditionFailed(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusPreconditionFailed).AddData(data)
+}
+func RequestEntityTooLarge(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusRequestEntityTooLarge).AddData(data)
+}
+func RequestURITooLong(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusRequestURITooLong).AddData(data)
+}
+func UnsupportedMediaType(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusUnsupportedMediaType).AddData(data)
+}
+func RequestedRangeNotSatisfiable(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusRequestedRangeNotSatisfiable).AddData(data)
+}
+func ExpectationFailed(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusExpectationFailed).AddData(data)
+}
+func Teapot(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusTeapot).AddData(data)
+}
+func MisdirectedRequest(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusMisdirectedRequest).AddData(data)
+}
+func UnprocessableEntity(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusUnprocessableEntity).AddData(data)
+}
+func Locked(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusLocked).AddData(data)
+}
+func FailedDependency(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusFailedDependency).AddData(data)
+}
+func TooEarly(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusTooEarly).AddData(data)
+}
+func UpgradeRequired(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusUpgradeRequired).AddData(data)
+}
+func PreconditionRequired(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusPreconditionRequired).AddData(data)
+}
+func TooManyRequests(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusTooManyRequests).AddData(data)
+}
+func RequestHeaderFieldsTooLarge(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusRequestHeaderFieldsTooLarge).AddData(data)
+}
+func UnavailableForLegalReasons(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusUnavailableForLegalReasons).AddData(data)
 }
 
 func InternalServerError(message string) *ResponseMessage {

--- a/response_helpers_test.go
+++ b/response_helpers_test.go
@@ -24,6 +24,37 @@ func TestAccepted(t *testing.T) {
 	checkResponseSuccess(resp, http.StatusAccepted)
 }
 
+func TestNonAuthoritativeInfo(t *testing.T) {
+	RegisterTestingT(t)
+	resp := NonAuthoritativeInfo("test")
+	checkResponseSuccess(resp, http.StatusNonAuthoritativeInfo)
+}
+func TestResetContent(t *testing.T) {
+	RegisterTestingT(t)
+	resp := ResetContent("test")
+	checkResponseSuccess(resp, http.StatusResetContent)
+}
+func TestPartialContent(t *testing.T) {
+	RegisterTestingT(t)
+	resp := PartialContent("test")
+	checkResponseSuccess(resp, http.StatusPartialContent)
+}
+func TestMultiStatus(t *testing.T) {
+	RegisterTestingT(t)
+	resp := MultiStatus("test")
+	checkResponseSuccess(resp, http.StatusMultiStatus)
+}
+func TestAlreadyReported(t *testing.T) {
+	RegisterTestingT(t)
+	resp := AlreadyReported("test")
+	checkResponseSuccess(resp, http.StatusAlreadyReported)
+}
+func TestIMUsed(t *testing.T) {
+	RegisterTestingT(t)
+	resp := IMUsed("test")
+	checkResponseSuccess(resp, http.StatusIMUsed)
+}
+
 func TestNoContent(t *testing.T) {
 	RegisterTestingT(t)
 	resp := NoContent()
@@ -70,6 +101,117 @@ func TestNotAcceptable(t *testing.T) {
 	RegisterTestingT(t)
 	resp := NotAcceptable("test")
 	checkResponseFail(resp, http.StatusNotAcceptable)
+}
+
+func TestProxyAuthRequired(t *testing.T) {
+	RegisterTestingT(t)
+	resp := ProxyAuthRequired("test")
+	checkResponseFail(resp, http.StatusProxyAuthRequired)
+}
+func TestRequestTimeout(t *testing.T) {
+	RegisterTestingT(t)
+	resp := RequestTimeout("test")
+	checkResponseFail(resp, http.StatusRequestTimeout)
+}
+func TestConflict(t *testing.T) {
+	RegisterTestingT(t)
+	resp := Conflict("test")
+	checkResponseFail(resp, http.StatusConflict)
+}
+func TestGone(t *testing.T) {
+	RegisterTestingT(t)
+	resp := Gone("test")
+	checkResponseFail(resp, http.StatusGone)
+}
+func TestLengthRequired(t *testing.T) {
+	RegisterTestingT(t)
+	resp := LengthRequired("test")
+	checkResponseFail(resp, http.StatusLengthRequired)
+}
+func TestPreconditionFailed(t *testing.T) {
+	RegisterTestingT(t)
+	resp := PreconditionFailed("test")
+	checkResponseFail(resp, http.StatusPreconditionFailed)
+}
+func TestRequestEntityTooLarge(t *testing.T) {
+	RegisterTestingT(t)
+	resp := RequestEntityTooLarge("test")
+	checkResponseFail(resp, http.StatusRequestEntityTooLarge)
+}
+func TestRequestURITooLong(t *testing.T) {
+	RegisterTestingT(t)
+	resp := RequestURITooLong("test")
+	checkResponseFail(resp, http.StatusRequestURITooLong)
+}
+func TestUnsupportedMediaType(t *testing.T) {
+	RegisterTestingT(t)
+	resp := UnsupportedMediaType("test")
+	checkResponseFail(resp, http.StatusUnsupportedMediaType)
+}
+func TestRequestedRangeNotSatisfiable(t *testing.T) {
+	RegisterTestingT(t)
+	resp := RequestedRangeNotSatisfiable("test")
+	checkResponseFail(resp, http.StatusRequestedRangeNotSatisfiable)
+}
+func TestExpectationFailed(t *testing.T) {
+	RegisterTestingT(t)
+	resp := ExpectationFailed("test")
+	checkResponseFail(resp, http.StatusExpectationFailed)
+}
+func TestTeapot(t *testing.T) {
+	RegisterTestingT(t)
+	resp := Teapot("test")
+	checkResponseFail(resp, http.StatusTeapot)
+}
+func TestMisdirectedRequest(t *testing.T) {
+	RegisterTestingT(t)
+	resp := MisdirectedRequest("test")
+	checkResponseFail(resp, http.StatusMisdirectedRequest)
+}
+func TestUnprocessableEntity(t *testing.T) {
+	RegisterTestingT(t)
+	resp := UnprocessableEntity("test")
+	checkResponseFail(resp, http.StatusUnprocessableEntity)
+}
+func TestLocked(t *testing.T) {
+	RegisterTestingT(t)
+	resp := Locked("test")
+	checkResponseFail(resp, http.StatusLocked)
+}
+func TestFailedDependency(t *testing.T) {
+	RegisterTestingT(t)
+	resp := FailedDependency("test")
+	checkResponseFail(resp, http.StatusFailedDependency)
+}
+func TestTooEarly(t *testing.T) {
+	RegisterTestingT(t)
+	resp := TooEarly("test")
+	checkResponseFail(resp, http.StatusTooEarly)
+}
+func TestUpgradeRequired(t *testing.T) {
+	RegisterTestingT(t)
+	resp := UpgradeRequired("test")
+	checkResponseFail(resp, http.StatusUpgradeRequired)
+}
+func TestPreconditionRequired(t *testing.T) {
+	RegisterTestingT(t)
+	resp := PreconditionRequired("test")
+	checkResponseFail(resp, http.StatusPreconditionRequired)
+}
+func TestTooManyRequests(t *testing.T) {
+	RegisterTestingT(t)
+	resp := TooManyRequests("test")
+	checkResponseFail(resp, http.StatusTooManyRequests)
+}
+func TestRequestHeaderFieldsTooLarge(t *testing.T) {
+	RegisterTestingT(t)
+	resp := RequestHeaderFieldsTooLarge("test")
+	checkResponseFail(resp, http.StatusRequestHeaderFieldsTooLarge)
+}
+func TestUnavailableForLegalReasons(t *testing.T) {
+	RegisterTestingT(t)
+	resp := UnavailableForLegalReasons("test")
+	checkResponseFail(resp, http.StatusUnavailableForLegalReasons)
 }
 
 func TestInternalServerError(t *testing.T) {

--- a/response_interface.go
+++ b/response_interface.go
@@ -1,0 +1,10 @@
+package httping
+
+import "net/http"
+
+type IResponse interface {
+	Headers() map[string][]string
+	Cookies() []*http.Cookie
+	Response() interface{}
+	StatusCode() int
+}

--- a/response_message.go
+++ b/response_message.go
@@ -20,6 +20,7 @@ const (
 	StatusFail    ResponseStatus = "fail"
 )
 
+// JSend helper. It follows all rules of JSend.
 func NewResponse(statusCode int) *ResponseMessage {
 	switch {
 	case statusCode >= http.StatusInternalServerError:
@@ -69,14 +70,18 @@ func (r *ResponseMessage) SetCookies(cookies []*http.Cookie) *ResponseMessage {
 	return r
 }
 
-func (r *ResponseMessage) GetStatusCode() int {
+func (r *ResponseMessage) StatusCode() int {
 	return r.statusCode
 }
 
-func (r *ResponseMessage) GetCookies() []*http.Cookie {
+func (r *ResponseMessage) Cookies() []*http.Cookie {
 	return r.cookies
 }
 
-func (r *ResponseMessage) GetHeaders() map[string][]string {
+func (r *ResponseMessage) Headers() map[string][]string {
 	return r.headers
+}
+
+func (r *ResponseMessage) Response() interface{} {
+	return r
 }

--- a/response_message_test.go
+++ b/response_message_test.go
@@ -16,7 +16,7 @@ func TestNewResponse(t *testing.T) {
 	Expect(resp.Data).To(BeNil())
 	Expect(resp.Message).To(BeEquivalentTo(""))
 	Expect(resp.statusCode).To(BeEquivalentTo(http.StatusOK))
-	Expect(resp.GetStatusCode()).To(BeEquivalentTo(http.StatusOK))
+	Expect(resp.StatusCode()).To(BeEquivalentTo(http.StatusOK))
 	Expect(len(resp.headers)).To(BeEquivalentTo(0))
 	resp.AddMessage("test message")
 	Expect(resp.Message).To(BeEquivalentTo(""))
@@ -45,7 +45,7 @@ func TestAddCode(t *testing.T) {
 	Expect(resp.Data).To(BeNil())
 	Expect(resp.Message).To(BeEquivalentTo(""))
 	Expect(resp.statusCode).To(BeEquivalentTo(http.StatusInternalServerError))
-	Expect(resp.GetStatusCode()).To(BeEquivalentTo(http.StatusInternalServerError))
+	Expect(resp.StatusCode()).To(BeEquivalentTo(http.StatusInternalServerError))
 	Expect(len(resp.headers)).To(BeEquivalentTo(0))
 }
 
@@ -88,7 +88,7 @@ func TestAddHeader(t *testing.T) {
 	Expect(resp.statusCode).To(BeEquivalentTo(http.StatusOK))
 	Expect(len(resp.headers)).To(BeEquivalentTo(1))
 	Expect(resp.headers["test key"][0]).To(BeEquivalentTo("test value"))
-	headers := resp.GetHeaders()
+	headers := resp.Headers()
 	Expect(len(headers)).To(BeEquivalentTo(1))
 	Expect(headers["test key"][0]).To(BeEquivalentTo("test value"))
 }
@@ -109,10 +109,10 @@ func TestAddCookie(t *testing.T) {
 	Expect(resp.Code).To(BeEquivalentTo(""))
 	Expect(resp.Data).To(BeNil())
 	Expect(resp.Message).To(BeEquivalentTo(""))
-	Expect(resp.GetStatusCode()).To(BeEquivalentTo(http.StatusOK))
-	Expect(len(resp.GetHeaders())).To(BeEquivalentTo(0))
-	Expect(len(resp.GetCookies())).To(BeEquivalentTo(1))
-	Expect(resp.GetCookies()[0]).To(BeEquivalentTo(cookie))
+	Expect(resp.StatusCode()).To(BeEquivalentTo(http.StatusOK))
+	Expect(len(resp.Headers())).To(BeEquivalentTo(0))
+	Expect(len(resp.Cookies())).To(BeEquivalentTo(1))
+	Expect(resp.Cookies()[0]).To(BeEquivalentTo(cookie))
 }
 
 func TestSetCookies(t *testing.T) {
@@ -134,9 +134,9 @@ func TestSetCookies(t *testing.T) {
 	Expect(resp.Code).To(BeEquivalentTo(""))
 	Expect(resp.Data).To(BeNil())
 	Expect(resp.Message).To(BeEquivalentTo(""))
-	Expect(resp.GetStatusCode()).To(BeEquivalentTo(http.StatusOK))
-	Expect(len(resp.GetHeaders())).To(BeEquivalentTo(0))
-	Expect(len(resp.GetCookies())).To(BeEquivalentTo(2))
-	Expect(resp.GetCookies()[0]).To(BeEquivalentTo(cookie))
-	Expect(resp.GetCookies()[1]).To(BeEquivalentTo(cookie))
+	Expect(resp.StatusCode()).To(BeEquivalentTo(http.StatusOK))
+	Expect(len(resp.Headers())).To(BeEquivalentTo(0))
+	Expect(len(resp.Cookies())).To(BeEquivalentTo(2))
+	Expect(resp.Cookies()[0]).To(BeEquivalentTo(cookie))
+	Expect(resp.Cookies()[1]).To(BeEquivalentTo(cookie))
 }

--- a/route.go
+++ b/route.go
@@ -7,13 +7,14 @@ import (
 	"strings"
 )
 
-type HandlerFunc func(request HttpRequest) (response *ResponseMessage)
+type HandlerFunc func(request HttpRequest) (response IResponse)
 
 type route struct {
 	route      *gin.RouterGroup
 	middleware []HandlerFunc
 }
 
+// Add a HandlerFunc that it will run every time that your server receives a request in the route with the method set up.
 func (r *route) AddMethod(method string, handler HandlerFunc) {
 	method = strings.ToUpper(method)
 	switch method {
@@ -103,7 +104,7 @@ func (r *route) getHandleFunc(handle HandlerFunc) func(c *gin.Context) {
 						Cookies: c.Request.Cookies(),
 					})
 					if message != nil {
-						c.JSON(message.statusCode, message)
+						c.JSON(message.StatusCode(), message.Response())
 						return
 					}
 				}
@@ -117,15 +118,15 @@ func (r *route) getHandleFunc(handle HandlerFunc) func(c *gin.Context) {
 			Cookies: c.Request.Cookies(),
 		})
 		if message != nil {
-			for k, v := range message.headers {
+			for k, v := range message.Headers() {
 				for _, h := range v {
 					c.Writer.Header().Add(k, h)
 				}
 			}
-			for _, v := range message.cookies {
+			for _, v := range message.Cookies() {
 				c.SetCookie(v.Name, v.Value, v.MaxAge, v.Path, v.Domain, v.Secure, v.HttpOnly)
 			}
-			c.JSON(message.statusCode, message)
+			c.JSON(message.StatusCode(), message.Response())
 			return
 		}
 		c.JSON(http.StatusOK, nil)

--- a/server_interface.go
+++ b/server_interface.go
@@ -5,4 +5,5 @@ type IServer interface {
 	RunServer() (ServerCloseFunc, chan error)
 	SetMiddleware(middleware []HandlerFunc) IServer
 	AddMiddleware(middleware HandlerFunc) IServer
+	EnableCORS() IServer
 }

--- a/version.go
+++ b/version.go
@@ -4,6 +4,6 @@ const ApplicationName = "httping-go"
 
 var GitCommit string
 
-const Version = "0.13.0"
+const Version = "0.14.0"
 
 var VersionPrerelease = ""


### PR DESCRIPTION
* IResponse implemented on the HandleFunc. It was only possible to reply JSend messages, now on, it is possible to
return anything that implements `IResponse` interface, which means anything besides JSend.
* `EnableCORS()` now on is a method on the `IServer`. To enable CORS it is only needed to call the method.
* Helpers for responses. **Status**: 
    * ProxyAuthRequired
    * RequestTimeout
    * Conflict
    * Gone
    * LengthRequired
    * PreconditionFailed
    * RequestEntityTooLarge
    * RequestURITooLong
    * UnsupportedMediaType
    * RequestedRangeNotSatisfiable
    * ExpectationFailed
    * Teapot
    * MisdirectedRequest
    * UnprocessableEntity
    * Locked
    * FailedDependency
    * TooEarly
    * UpgradeRequired
    * PreconditionRequired
    * TooManyRequests
    * RequestHeaderFieldsTooLarge
    * UnavailableForLegalReasons
    * NonAuthoritativeInfo
    * ResetContent
    * PartialContent
    * MultiStatus
    * AlreadyReported
    * IMUsed
* Go doc support